### PR TITLE
Support Firefox 10 on some Linux versions.

### DIFF
--- a/jquery.websocket.js
+++ b/jquery.websocket.js
@@ -11,9 +11,9 @@
 (function($){
     $.extend({
         websocket: function(url, s) {
-        	if (typeof(WebSocket) == "undefined") {
-        		WebSocket = (MozWebSocket) ? MozWebSocket : null;
-        	}
+       	    if (typeof(WebSocket) == "undefined") {
+       	        WebSocket = (MozWebSocket) ? MozWebSocket : null;
+       	    }
             var ws = WebSocket ? new WebSocket( url ) : {
                 send: function(m){ return false },
                 close: function(){}


### PR DESCRIPTION
Firefox ESR 10.0.0.8 is the current shipping version of Firefox on Red Hat Enterprise Linux 6 and CentOS 6.

This pull request tests that WebSocket is defined, and if not, defines it as either MozWebSocket or null. 
