### PR TITLE
Optional protocols parameter in WebSocket constructor.

### DIFF
--- a/jquery.websocket.js
+++ b/jquery.websocket.js
@@ -11,6 +11,7 @@
 (function($){
     $.extend({
         websocket: function(url, s, protocols) {
+			protocols = protocols || [];
             var ws = window['MozWebSocket'] ? new MozWebSocket(url, protocols) : window['WebSocket'] ? new WebSocket(url, protocols) : {
                         send: function(m){ return false; },
                         close: function(){}


### PR DESCRIPTION
Hi

According to http://www.w3.org/TR/websockets/#websocket the WebSocket
constructor has a second optional parameter to specify the protocols, the client
speaks.

This parameter populates the 'Sec-WebSocket-Protocol' header.

Thanks
Valentin
